### PR TITLE
Tc simulation does not run if space in file path

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,9 @@
     m: minor
     p: patch
 
+## 1.4.1
+* p: simulation run if file path contains space
+
 ## 1.4.0
 * m: idd 22.1.0 was added
 

--- a/opyplus/simulation/simulation.py
+++ b/opyplus/simulation/simulation.py
@@ -261,7 +261,7 @@ class Simulation:
         if idf_command_style == SIMULATION_INPUT_COMMAND_STYLES.simu_dir:
             idf_file_cmd = os.path.join(self._dir_abs_path, CONF.default_model_name)
         elif idf_command_style == SIMULATION_INPUT_COMMAND_STYLES.file_path:
-            idf_file_cmd = self.get_resource_path("idf")
+            idf_file_cmd = self._resource_map[ResourcesRefs.idf]  # we use rel path
         else:
             raise AssertionError("should not be here")
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -3,8 +3,8 @@ from opyplus import CONF
 TESTED_EPLUS_VERSIONS = [
     # (8, 5, 0),
     # (8, 6, 0),
-    (9, 0, 1)  # todo: manage 9.2.0
-    # (9, 2, 0),  # todo: manage 9.2.0
+    # (9, 0, 1)  # todo: manage 9.2.0
+    (9, 2, 0),  # todo: manage 9.2.0
     # (22, 1, 0),
 ]
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -3,8 +3,8 @@ from opyplus import CONF
 TESTED_EPLUS_VERSIONS = [
     # (8, 5, 0),
     # (8, 6, 0),
-    # (9, 0, 1)  # todo: manage 9.2.0
-    (9, 2, 0),  # todo: manage 9.2.0
+    (9, 0, 1)  # todo: manage 9.2.0
+    # (9, 2, 0),  # todo: manage 9.2.0
     # (22, 1, 0),
 ]
 


### PR DESCRIPTION
Fixes #55 by using relative path for the `idf` file. @geoffroy-destaintot I wrote a small  test to check everything was okay, but not sure if there was a good reason for the `epw` file to use relative path in the command line while the `idf` was referenced using absolute path. Another way tha fixes the issue is to keep the absolute path but escaping blank spaces using `.replace(" ", "\ ")`.