### PR TITLE
Allow schedule type limit to be set at "On/Off"

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,9 @@
     m: minor
     p: patch
 
+## next
+* p: from version 9.2, allow schedule type limit to be set at "On/Off"
+
 ## 1.4.0
 * m: idd 22.1.0 was added
 

--- a/opyplus/idd/idd_debug.py
+++ b/opyplus/idd/idd_debug.py
@@ -54,3 +54,18 @@ def correct_idd(idd):
         td = idd.table_descriptors["comfortviewfactorangles"]
         fd = td.get_field_descriptor(2)
         fd.append_tag("begin-extensible")
+
+    # for all version >= 9.2, add key On/Off for object listing ScheduleTypeLimitNames
+    if idd.version >= (9, 2, 0):
+        for table_ref, table_descriptor in idd.table_descriptors.items():
+            field_descriptor_names = [fd.name for fd in table_descriptor._field_descriptors]
+            field_name = 'Schedule Type Limits Name'
+            if field_name in field_descriptor_names:
+                field_index = table_descriptor.get_field_index(field_name.lower().replace(" ", "_"))
+                field_descriptor = table_descriptor.get_field_descriptor(field_index)
+                field_descriptor.append_tag("key", "On/Off")
+                field_descriptor.tags.update({
+                    "type": ["choice"],
+                    "key": ["On/Off"]
+                })
+

--- a/tests/test_idd.py
+++ b/tests/test_idd.py
@@ -1,6 +1,7 @@
 import unittest
+import os
 
-from opyplus.idd.idd import Idd
+import opyplus as op
 
 from tests.util import iter_eplus_versions
 
@@ -8,6 +9,19 @@ from tests.util import iter_eplus_versions
 class IddTest(unittest.TestCase):
     def test_load(self):
         for _ in iter_eplus_versions(self):
-            idd = Idd()
+            idd = op.Idd()
+
+    def test_on_off_schedule_type_limit(self):
+        for eplus_version in iter_eplus_versions(self):
+            if eplus_version >= (9, 2, 0):
+                epm = op.Epm(idd_or_version=eplus_version)  # empty epm
+                epm.Schedule_Compact.add(
+                    name="test_on_off",
+                    schedule_type_limit_names="on/off",
+                    field_1="through: 12/31",
+                    field_2="for: alldays",
+                    field_3="until: 24:00",
+                    field_4="1"
+                )
 
 


### PR DESCRIPTION
Fixes #58 by correcting IDD files from version 9.2, making "On/Off" option explicit.