### PR TITLE
Preserve order of EMS calling manager

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,11 @@
     m: minor
     p: patch
 
+## next
+* p: preserve order of ``EnergyManagementSystem:ProgramCallingManager`` objects when saving
+``Epm``.
+* p: handle 0-length records
+
 ## 1.4.1
 * p: simulation run if file path contains space now works
 

--- a/opyplus/epm/epm.py
+++ b/opyplus/epm/epm.py
@@ -461,10 +461,17 @@ class Epm:
                 target_dir_path=os.path.join(dir_path, get_external_files_dir_name(model_name=model_name))
             )
 
+        def _sort(table, table_ref, exclude=()):
+            if table_ref in exclude:
+                return table
+            return sorted(table)
+
         # prepare body
         formatted_records = []
+        order_dependent_records = ("energymanagementsystem_programcallingmanager",)
         for table_ref, table in self._tables.items():  # self._tables is already sorted
-            formatted_records.extend([r.to_idf(model_name=model_name) for r in sorted(table)])
+            formatted_records.extend([
+                r.to_idf(model_name=model_name) for r in _sort(table, table_ref, order_dependent_records)])
         body = "\n\n".join(formatted_records)
 
         # return

--- a/opyplus/epm/record.py
+++ b/opyplus/epm/record.py
@@ -831,8 +831,10 @@ class Record:
         # fields
         # fields_nb: we don't use len(self) but max(self). We wan't to stop if no more values (even base fields)
         #   because some idd records are defined without extensibles (although they should used them), for example
-        #   construction, and eplus does not know what to do...
-        fields_nb = max(self._data)+1
+        #   construction, and eplus does not know what to do... Because some example files (e.g.
+        #   ASHRAE9012016_Warehouse_Denver.idf) have records for which len(self._data) == 0, we set field_nb to 1
+        #   in this case to prevent max of an empty arg to raise an error.
+        fields_nb = max(self._data)+1 if len(self._data) else 1
         for i in range(fields_nb):
             # value
             tab = " " * TAB_LEN


### PR DESCRIPTION
Fix #59 by preserving order in EMS program calling managers when saving the `Epm`.