### PR TITLE
read the docs fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-python>=3.8  # readthedocs bug fix
 sphinx>=2.3.1,<3.0
 autodoc>=0.5.0,<0.6
 sphinx-rtd-theme>=0.4.3,<0.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,3 @@ sphinx-rtd-theme>=0.4.3,<0.5
 m2r>=0.2.1,<0.3
 numpydoc>=0.9.2,<0.10.0
 plotly  # used in some samples
-mistune==0.8.4  # debug : https://github.com/Tribler/tribler/issues/6624
-Jinja2<3.1  # debug: https://github.com/readthedocs/readthedocs.org/issues/9038

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ m2r>=0.2.1,<0.3
 numpydoc>=0.9.2,<0.10.0
 plotly  # used in some samples
 mistune==0.8.4  # debug : https://github.com/Tribler/tribler/issues/6624
+Jinja2<3.1  # debug: https://github.com/readthedocs/readthedocs.org/issues/9038

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-rtd-theme>=0.4.3,<0.5
 m2r>=0.2.1,<0.3
 numpydoc>=0.9.2,<0.10.0
 plotly  # used in some samples
+mistune==0.8.4  # debug : https://github.com/Tribler/tribler/issues/6624

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pandas>=0.20.0,<2.0.0
-numpy  # added because numpy is not automatically installed by readthedocs
 unidecode>=1.0.22,<2.0
 python-slugify>=3.0.2,<4.0
 cchardet>=2.1.4,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy  # added because numpy is not automatically installed by readthedocs
 unidecode>=1.0.22,<2.0
 python-slugify>=3.0.2,<4.0
 cchardet>=2.1.4,<3.0
+mistune==0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy  # added because numpy is not automatically installed by readthedocs
 unidecode>=1.0.22,<2.0
 python-slugify>=3.0.2,<4.0
 cchardet>=2.1.4,<3.0
-mistune==0.8.4


### PR DESCRIPTION
numpy compilation solved by setting "advanced parameters > use system packages" on readthedocs interface
removed requirements not necessary anymore for readthedocs compilation
