### PR TITLE
Resolve #81

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas>=0.20.0,<2.0.0
 unidecode>=1.0.22,<2.0
 python-slugify>=3.0.2,<4.0
-cchardet>=2.1.4,<3.0
+faust-cchardet>=2.1.4,<3.0


### PR DESCRIPTION
[cchardet](https://github.com/PyYoshi/cChardet), a dependency of opyplus, https://github.com/PyYoshi/cChardet/issues/81; it looks like cchardet has been abandoned so a fork, [faust-cchardet](https://github.com/faust-streaming/cChardet), has been created which builds on Python 3.11.

This PR simply replaces cchardet with faust-cchardet.